### PR TITLE
replace deprecated OCP\image_path with template function

### DIFF
--- a/templates/addBookmarklet.php
+++ b/templates/addBookmarklet.php
@@ -11,7 +11,7 @@ $bookmarkExists = $_['bookmarkExists'];
 		<script type="text/javascript" src="tag"></script>
 
 		<h1 style="display: block; float: left"><?php p($l->t('Add a bookmark')); ?></h1>
-		<span style="display: inline; float: right"><div id="add_form_loading" style="margin: 3px;"><img src="<?php print_unescaped(OCP\image_path("bookmarks", "loading.gif")); ?>"> </div></span>
+		<span style="display: inline; float: right"><div id="add_form_loading" style="margin: 3px;"><img src="<?php print_unescaped(image_path("bookmarks", "loading.gif")); ?>"> </div></span>
 
 		<div style="color: red; clear: both; visibility: <?php
 		if ($bookmarkExists === false) {

--- a/templates/js_tpl.php
+++ b/templates/js_tpl.php
@@ -2,7 +2,7 @@
     <div class="bookmark_single" data-id="<&= id &>">
         <p class="bookmark_actions">
             <span class="bookmark_delete">
-                <img class="svg" src="<?php print_unescaped(OCP\image_path("", "actions/delete.svg")); ?>"
+                <img class="svg" src="<?php print_unescaped(image_path("", "actions/delete.svg")); ?>"
                      title="<?php p($l->t('Delete')); ?>">
             </span>&nbsp;
         </p>
@@ -11,7 +11,7 @@
                 <&= escapeHTML(title == '' ? encodeURI(url) : title ) &>
             </a>
             <span class="bookmark_edit bookmark_edit_btn">
-                <img class="svg" src="<?php print_unescaped(OCP\image_path("", "actions/rename.svg")); ?>" title="<?php p($l->t('Edit')); ?>">
+                <img class="svg" src="<?php print_unescaped(image_path("", "actions/rename.svg")); ?>" title="<?php p($l->t('Edit')); ?>">
             </span>
         </p>
         <span class="bookmark_desc"><&= escapeHTML(description)&> </span>
@@ -51,11 +51,11 @@
     <li><a href="" class="tag"><&= escapeHTML(tag) &></a>
         <div class="tags_actions">
             <span class="tag_delete">
-                <img class="svg" src="<?php print_unescaped(OCP\image_path("", "actions/delete.svg")); ?>"
+                <img class="svg" src="<?php print_unescaped(image_path("", "actions/delete.svg")); ?>"
                      title="<?php p($l->t('Delete')); ?>">
             </span>
             <span class="tag_edit">
-                <img class="svg" src="<?php print_unescaped(OCP\image_path("", "actions/rename.svg")); ?>"
+                <img class="svg" src="<?php print_unescaped(image_path("", "actions/rename.svg")); ?>"
                      title="<?php p($l->t('Edit')); ?>">
             </span>
             <em><&= nbr &></em>


### PR DESCRIPTION
Required for ownCloud 10.2 where it was removed
See upstream commit:
https://github.com/nextcloud/bookmarks/commit/4b3c3b1d6042e0ed27bd29889be8ead33aa07ceb#diff-f4970676746c433686cc9b1652e4aace